### PR TITLE
chore: setting explicit versions in docker-compose for dev infrastruc…

### DIFF
--- a/apps/nestjs-backend/docker-compose.yml
+++ b/apps/nestjs-backend/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres
+    image: postgres:16.9-bullseye
     restart: always
     ports:
       - '${POSTGRES_PORT}:5432'
@@ -13,7 +13,7 @@ services:
       TZ: '${POSTGRES_TIMEZONE}'
 
   maildev:
-    image: maildev/maildev
+    image: maildev/maildev:2.2.1
     restart: always
     ports:
       - '${MAILDEV_WEB_PORT}:1080' # Web interface


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file in the `apps/nestjs-backend` directory to specify more precise image versions for services. These changes ensure compatibility and stability by pinning specific versions of the `postgres` and `maildev` images.

Version updates for Docker services:

* Updated the `postgres` service to use the `postgres:16.9-bullseye` image instead of the generic `postgres` image.
* Updated the `maildev` service to use the `maildev/maildev:2.2.1` image instead of the generic `maildev/maildev` image.…ture